### PR TITLE
Add coverage for supporters helpers and itinerary summary

### DIFF
--- a/tests/Unit/Dtos/Planner/ItinerarySummaryTest.php
+++ b/tests/Unit/Dtos/Planner/ItinerarySummaryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Nezasa\Checkout\Dtos\Planner\Entities\ItineraryStay;
+use Nezasa\Checkout\Dtos\Planner\ItinerarySummary;
+use Nezasa\Checkout\Integrations\Nezasa\Dtos\Responses\ApplyPromoCodeResponse;
+use Nezasa\Checkout\Integrations\Nezasa\Dtos\Responses\Entities\ExternallyPaidChargesResponseEntity;
+use Nezasa\Checkout\Integrations\Nezasa\Dtos\Responses\Entities\TermsAndConditionsResponseEntity;
+use Nezasa\Checkout\Integrations\Nezasa\Dtos\Shared\Price;
+use Nezasa\Checkout\Integrations\Nezasa\Enums\AvailabilityEnum;
+
+function buildPriceSet(): ApplyPromoCodeResponse {
+    return new ApplyPromoCodeResponse(
+        discountedPackagePrice: new Price(1000, 'CHF'),
+        packagePrice: new Price(1200, 'CHF'),
+        totalPackagePrice: new Price(1200, 'CHF'),
+        downPayment: new Price(200, 'CHF'),
+        externallyPaidCharges: new ExternallyPaidChargesResponseEntity(totalPrice: new Price(0, 'CHF')),
+    );
+}
+
+it('computes group availability statuses when items share the same status', function (): void {
+    $price = buildPriceSet();
+    $start = CarbonImmutable::parse('2024-06-01');
+    $stayStatus = AvailabilityEnum::Available;
+
+    $summary = new ItinerarySummary(
+        price: $price,
+        title: 'Trip',
+        startDate: $start,
+        endDate: $start->addDays(3),
+        adults: 2,
+        stays: new Collection([
+            new ItineraryStay('s1', 'Stay 1', $start, 1, $stayStatus),
+            new ItineraryStay('s2', 'Stay 2', $start->addDay(), 2, $stayStatus),
+        ]),
+        termsAndConditions: new TermsAndConditionsResponseEntity,
+    );
+
+    expect($summary->getHotelsGroupStatus())->toBe($stayStatus);
+});
+
+it('returns null group status when availability differs', function (): void {
+    $price = buildPriceSet();
+    $start = CarbonImmutable::parse('2024-06-01');
+
+    $summary = new ItinerarySummary(
+        price: $price,
+        title: 'Trip',
+        startDate: $start,
+        endDate: $start->addDays(2),
+        adults: 2,
+        stays: new Collection([
+            new ItineraryStay('s1', 'Stay 1', $start, 1, AvailabilityEnum::Available),
+            new ItineraryStay('s2', 'Stay 2', $start->addDay(), 1, AvailabilityEnum::OnRequest),
+        ]),
+        termsAndConditions: new TermsAndConditionsResponseEntity,
+    );
+
+    expect($summary->getHotelsGroupStatus())->toBeNull();
+});

--- a/tests/Unit/Helpers/HelpersTest.php
+++ b/tests/Unit/Helpers/HelpersTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Http\Request;
+use Nezasa\Checkout\Dtos\Checkout\CheckoutParamsDto;
+
+it('resolves checkout_path to package root and subpaths', function (): void {
+    $root = checkout_path();
+
+    expect(is_dir($root))->toBeTrue()
+        ->and(checkout_path('src'))->toBe($root.DIRECTORY_SEPARATOR.'src');
+});
+
+it('builds checkout params from the current request', function (): void {
+    $request = Request::create('/checkout/details', 'GET', [
+        'checkoutId' => 'co-200',
+        'itineraryId' => 'it-300',
+        'origin' => 'ibe',
+        'lang' => 'de',
+        'restPayment' => '1',
+    ]);
+
+    app()->instance('request', $request);
+
+    $dto = checkout_params();
+
+    expect($dto)->toBeInstanceOf(CheckoutParamsDto::class)
+        ->and($dto->checkoutId)->toBe('co-200')
+        ->and($dto->itineraryId)->toBe('it-300')
+        ->and($dto->origin)->toBe('ibe')
+        ->and($dto->lang)->toBe('de')
+        ->and($dto->restPayment)->toBeTrue();
+});

--- a/tests/Unit/Supporters/AutoCompleteSupporterTest.php
+++ b/tests/Unit/Supporters/AutoCompleteSupporterTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Nezasa\Checkout\Supporters\AutoCompleteSupporter;
+
+it('returns autocomplete token when field is mapped', function (): void {
+    expect(AutoCompleteSupporter::get('firstName'))->toBe('autocomplete=given-name')
+        ->and(AutoCompleteSupporter::get('postalCode'))->toBe('autocomplete=postal-code');
+});
+
+it('returns empty string for unknown fields', function (): void {
+    expect(AutoCompleteSupporter::get('unknown'))->toBe('');
+});

--- a/tests/Unit/Supporters/AvailabilitySupporterTest.php
+++ b/tests/Unit/Supporters/AvailabilitySupporterTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Mockery as m;
+use Nezasa\Checkout\Dtos\Checkout\CheckoutParamsDto;
+use Nezasa\Checkout\Supporters\AvailabilitySupporter;
+use Saloon\Http\Response;
+
+beforeEach(function (): void {
+    config()->set('cache.default', 'array');
+    Cache::clear();
+});
+
+it('stores and retrieves availability results from cache', function (): void {
+    $params = new CheckoutParamsDto('co-1', 'it-1', 'ibe');
+    $response = m::mock(Response::class);
+    $response->shouldReceive('array')->andReturn(['ok' => true]);
+    $response->shouldReceive('status')->andReturn(202);
+
+    $supporter = new AvailabilitySupporter();
+    $supporter->cacheResult($params, $response);
+
+    expect($supporter->has($params))->toBeTrue()
+        ->and($supporter->getCachedResult($params))->toBe(['ok' => true])
+        ->and($supporter->getCachedStatus($params))->toBe(202);
+
+    $supporter->clearCache($params);
+
+    expect($supporter->has($params))->toBeFalse();
+});

--- a/tests/Unit/Supporters/InsuranceSupporterTest.php
+++ b/tests/Unit/Supporters/InsuranceSupporterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Nezasa\Checkout\Supporters\InsuranceSupporter;
+
+it('detects when exactly one insurance provider is active', function (): void {
+    Config::set('checkout.insurance', [
+        ['active' => false],
+        ['active' => true],
+    ]);
+
+    expect(InsuranceSupporter::isAvailable())->toBeTrue();
+});
+
+it('returns false when no provider is active', function (): void {
+    Config::set('checkout.insurance', [
+        ['active' => false],
+        ['active' => false],
+    ]);
+
+    expect(InsuranceSupporter::isAvailable())->toBeFalse();
+});
+
+it('throws when more than one provider is active', function (): void {
+    Config::set('checkout.insurance', [
+        ['active' => true],
+        ['active' => true],
+    ]);
+
+    InsuranceSupporter::isAvailable();
+})->throws(Exception::class, 'Only one insurance provider can be active at a time.');


### PR DESCRIPTION
## Summary
- add Pest unit tests for autocomplete helpers and insurance availability logic
- cover availability caching supporter and checkout helper utilities
- verify itinerary summary grouping behaviour for stay availability statuses

## Testing
- Not run (composer install failed due to network restrictions)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ecb32aaa48331b0cde559d16de5e9)