### PR TITLE
MLZ-4795: Fix incorrect property assignment for itinerary stay name i…

### DIFF
--- a/src/Actions/Planner/SummarizeItineraryAction.php
+++ b/src/Actions/Planner/SummarizeItineraryAction.php
@@ -117,7 +117,7 @@ class SummarizeItineraryAction
             $this->result->stays->push(
                 new ItineraryStay(
                     id: $hotel->id,
-                    name: $hotel->location->name,
+                    name: $hotel->name,
                     checkIn: $hotel->startDate,
                     nights: $hotel->nights
                 )

--- a/tests/.pest/snapshots/Unit/Actions/Planner/SummarizeItineraryActionTest/it_summarizes_an_itinerary.snap
+++ b/tests/.pest/snapshots/Unit/Actions/Planner/SummarizeItineraryActionTest/it_summarizes_an_itinerary.snap
@@ -89,7 +89,7 @@
         {
             "checkOut": "2025-12-21T11:20:19+00:00",
             "id": "68ad5b3c590000525ed60ed9",
-            "name": "Roma",
+            "name": "Residenza Antica",
             "checkIn": "2025-12-18T11:20:19+00:00",
             "nights": 3,
             "availability": null


### PR DESCRIPTION
…n `SummarizeItineraryAction`.